### PR TITLE
Typo: pip install effi to pip install cffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## install:
 ```
-pip install effi
+pip install cffi
 ```
 
 ## underlying implementation


### PR DESCRIPTION
Typo: pip install effi to pip install cffi